### PR TITLE
Update Kubectl Plugin - v0.0.3

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: clu
 spec:
-  version: "v0.0.1"
+  version: "v0.0.3"
   homepage: https://github.com/jkremser/kubectl-clu
   shortDescription: "Simple TUI based shell script for templating the GiantSwarm clusters."
   description: |
@@ -16,9 +16,9 @@ spec:
             values:
               - darwin
               - linux
-      uri: https://github.com/jkremser/kubectl-clu/archive/refs/tags/v0.0.1.zip
+      uri: https://github.com/jkremser/kubectl-clu/archive/refs/tags/v0.0.3.zip
       # 'sha256' is the sha256sum of the zip from url above (shasum -a 256 ..zip)
-      sha256: edf4e9d8c3c52cb195710a8fc1562ac017e240c60fb29c888c378c2fcfeee2cf
+      sha256: 8a9896514413af36776a5a318170fff96f151bca3dd19b98917f86a376c46314
       # {{addURIAndSha "https://github.com/jkremser/kubectl-clu/releases/download/{{ .TagName }}/kubectl-clu_{{ .TagName }}.tar.gz" .TagName }}
       files:
         - from: "kubectl-clu-*/kubectl-clu"


### PR DESCRIPTION
:package: Updating kubectl plugin :package:

new yaml manifest for release `v0.0.3`
Make sure the version is correctly set in VERSION file.
This needs to be done before creating the tag for release.

This automated PR was created by [this action][1].

[1]: https://github.com/jkremser/kubectl-clu/actions/runs/6576894186