### PR TITLE
Update Kubectl Plugin - v0.1.0

### DIFF
--- a/.krew.yaml
+++ b/.krew.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: clu
 spec:
-  version: "v0.0.9"
+  version: "v0.1.0"
   homepage: https://github.com/jkremser/kubectl-clu
   shortDescription: "Simple TUI based shell script for templating the GiantSwarm clusters."
   description: |
@@ -16,9 +16,9 @@ spec:
             values:
               - darwin
               - linux
-      uri: https://github.com/jkremser/kubectl-clu/archive/refs/tags/v0.0.9.zip
+      uri: https://github.com/jkremser/kubectl-clu/archive/refs/tags/v0.1.0.zip
       # 'sha256' is the sha256sum of the zip from url above (shasum -a 256 ..zip)
-      sha256: 0b6771eb3f8c5f1893a57a5d985a68b48a512066bb6aa98956132bf327e25a0b
+      sha256: 3b2d5621c790f946f3c1cab784e1c23c6590d6625ec83aa16445d342d5082a82
       # {{addURIAndSha "https://github.com/jkremser/kubectl-clu/releases/download/{{ .TagName }}/kubectl-clu_{{ .TagName }}.tar.gz" .TagName }}
       files:
         - from: "kubectl-clu-*/kubectl-clu"


### PR DESCRIPTION
:package: Updating kubectl plugin :package:

new yaml manifest for release `v0.1.0`
Make sure the version is correctly set in VERSION file.
This needs to be done before creating the tag for release.

This automated PR was created by [this action][1].

[1]: https://github.com/jkremser/kubectl-clu/actions/runs/6814107021